### PR TITLE
Removed field listeners from DomContentLoaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <input id="end-trim-value" class="trim-gauge" type="number">
             <select name="filetype-select" id="filetype-select">
                 <option value="mp4">.mp4</option>
-                <option value="avi">.avi</option>
+                <!-- <option value="avi">.avi</option> known bug - removed for now -->
                 <option value="mov">.mov</option>
                 <option value="webm">.webm</option>
             </select>

--- a/streamer.js
+++ b/streamer.js
@@ -2,33 +2,33 @@ const { createFFmpeg, fetchFile } = FFmpeg;
 const ffmpeg = createFFmpeg({ log: true });
 var debug = true;
 
+let beginTrim = document.getElementById("begin-trim");
+beginTrim.addEventListener("click", function()
+{
+    if (debug)
+    {
+        console.log("Trim requested...");
+    }
+    let startTrimValue = document.getElementById("start-trim-value").value,
+    endTrimValue = document.getElementById("end-trim-value").value;
+    validateTrim(startTrimValue, endTrimValue, videoPlayer);
+});
+
+var videoPlayer = videojs("video", {
+    fluid: true
+});
+
+(async () => {
+    await ffmpeg.load();
+})();
+
 document.addEventListener("DOMContentLoaded", function() 
 {
     if (debug)
     {
         console.log("DOM Content loaded.");
     }
-
-    var videoPlayer = videojs("video", {
-        fluid: true
-    });
-
-    let beginTrim = document.getElementById("begin-trim");
-    beginTrim.addEventListener("click", function()
-    {
-        if (debug)
-        {
-            console.log("Trim requested...");
-        }
-        let startTrimValue = document.getElementById("start-trim-value").value,
-    	endTrimValue = document.getElementById("end-trim-value").value;
-        validateTrim(startTrimValue, endTrimValue, videoPlayer);
-    });
 });
-
-(async () => {
-  await ffmpeg.load();
-})();
 
 function displayVideo()
 {

--- a/streamer.js
+++ b/streamer.js
@@ -1,7 +1,23 @@
-const { createFFmpeg, fetchFile } = FFmpeg;
-const ffmpeg = createFFmpeg({ log: true });
-var debug = true;
+/*
+By Connor T
+Edited 2/5/21
+Streamer logic for the Qoom video editor
+https://github.com/Rivers-dev/Qoom-Video-Editor
+*/
 
+const { createFFmpeg, fetchFile } = FFmpeg; //Load ffmpeg/wasm and the fetchfile module (used for telling ffmpeg what to edit)
+const ffmpeg = createFFmpeg({ log: true }); //Create ffmpeg object with logging ON
+var debug = false; //Debug variable that triggers various logging within the program
+
+(async () => { //Load ffmpeg when the webpage starts and wait for it
+    await ffmpeg.load();
+})();
+
+var videoPlayer = videojs("video", { //Load VideoJS. It's not in use now, but I plan to use it in the future
+    fluid: true
+});
+
+//Adding event listeners 
 let beginTrim = document.getElementById("begin-trim");
 beginTrim.addEventListener("click", function()
 {
@@ -9,18 +25,9 @@ beginTrim.addEventListener("click", function()
     {
         console.log("Trim requested...");
     }
-    let startTrimValue = document.getElementById("start-trim-value").value,
-    endTrimValue = document.getElementById("end-trim-value").value;
+    let startTrimValue = document.getElementById("start-trim-value").value, endTrimValue = document.getElementById("end-trim-value").value;
     validateTrim(startTrimValue, endTrimValue, videoPlayer);
 });
-
-var videoPlayer = videojs("video", {
-    fluid: true
-});
-
-(async () => {
-    await ffmpeg.load();
-})();
 
 document.addEventListener("DOMContentLoaded", function() 
 {
@@ -30,6 +37,7 @@ document.addEventListener("DOMContentLoaded", function()
     }
 });
 
+//Load the video that the user uploads
 function displayVideo()
 {
     let fileInput = document.getElementById("file-input");
@@ -42,6 +50,7 @@ function displayVideo()
     videoElement.play();
 }
 
+//Verify and execute the trim
 function validateTrim(st, et, p) //Function takes entered time and videoPlayer object
 {
     if (debug)
@@ -53,17 +62,17 @@ function validateTrim(st, et, p) //Function takes entered time and videoPlayer o
     {
         let fileInput = document.getElementById("file-input");
         let file = fileInput.files[0];
-        if (file == undefined)
+        if (file == undefined) //User doesn't add a video before pressing trim
         {
             alert("Select a video from your system to begin editing!");
             return;
         }
-        else if (isNaN(parseInt(st)) || isNaN(parseInt(et)))
+        else if (isNaN(parseInt(st)) || isNaN(parseInt(et))) //Prevents non-integer breakpoints (I think)
         {
             alert("Please enter valid numbers to trim!");
             return;
         }
-        else if (parseInt(st) >= parseInt(et))
+        else if (parseInt(st) >= parseInt(et)) //Prevents the user from making the end breakpoint earlier than the start breakpoint
         {
             alert("Please ensure that the start breakpoint is earlier than the end breakpoint!");
             return;
@@ -74,22 +83,26 @@ function validateTrim(st, et, p) //Function takes entered time and videoPlayer o
         let selectedFiletype = filetypeOptions.value, loadingLabel = document.querySelector(".progress-bar-label"), loadingBar = document.getElementById("bar");
         try
         {
-            await ffmpeg.FS("writeFile", "input." + inputFileType, data);
-            progressElement.innerHTML = "Converting...";
-            loadingBar.style.visibility = "visible";
+            await ffmpeg.FS("writeFile", "input." + inputFileType, data); //Write a temporary file with the contents of the user-inputted file
+            progressElement.innerHTML = "Converting..."; //Update progress label
+            loadingBar.style.visibility = "visible"; //Make loading bar visible
             loadingLabel.style.visibility = "visible";
+
+            //Get the progress of the conversion and convert it to a ratio to change the loading bar width
             await ffmpeg.setProgress(({ratio}) => {
                 console.log(ratio);
                 progressRatio = ratio * 100;
                 console.log(progressRatio);
                 loadingBar.style.width = progressRatio + "%";
             });
+
+            //Runs the main conversion
             await ffmpeg.run("-i", "input." + inputFileType, "-ss", st, "-to", et, "-async", "1", "output." + selectedFiletype);
     
             progressElement.innerHTML = "Done converting!";
-            let content = await ffmpeg.FS("readFile", "output." + selectedFiletype); //Returns a Uint8Array
-            resultElement.src = URL.createObjectURL(new Blob([content], {type: "video/mp4"}));
-            resultElement.style.visibility = "visible";
+            let content = await ffmpeg.FS("readFile", "output." + selectedFiletype); //Returns a Uint8Array; raw data output
+            resultElement.src = URL.createObjectURL(new Blob([content], {type: "video/" + selectedFiletype})); //Makes a new blob with the resulting file as the source of the video element
+            resultElement.style.visibility = "visible"; //Makes the lower video element visible
         }
         catch(err)
         {


### PR DESCRIPTION
The trim button and breakpoint fields used to have event listeners attached within DomContentLoaded, but type="module" on the script tag in the html makes this unnecessary. Also added many more comments and cleaned up the code a bit. 